### PR TITLE
Fix incorrect error message

### DIFF
--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -55,7 +55,7 @@ pub unsafe extern "C" fn save_omikuji_model(model_ptr: *mut Model, path: *const 
         .and_then(|path| {
             (*model_ptr)
                 .save(path)
-                .map_err(|e| format!("Failed to load model: {}", e))
+                .map_err(|e| format!("Failed to save model: {}", e))
         })
     {
         eprintln!("{}", msg);


### PR DESCRIPTION
Hi, I got a curious-looking error message when testing Omikuji - "Failed to load model" when the model was being saved. Looks like a copy-paste error to me. This PR fixes it.