### PR TITLE
Add Trove classifiers for Python 3.5 and 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,10 @@ setup(
     milksnake_universal=False,
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Rust",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Since Omikuji now works with Python 3.8 (yay!) and also 3.5, it could be a good idea to add those versions to the list of Trove classifiers.