### PR TITLE
Change weight matrix storage to significantly speed up prediction while using less memory

### DIFF
--- a/src/mat_util.rs
+++ b/src/mat_util.rs
@@ -383,7 +383,7 @@ where
 pub struct LilMat {
     outer_dim: usize,
     inner_dim: usize,
-    indptr: Vec<Index>,
+    indptr: Vec<usize>,
     outer_inds: Vec<Index>,
     inner_inds: Vec<Index>,
     data: Vec<f32>,

--- a/src/mat_util.rs
+++ b/src/mat_util.rs
@@ -19,7 +19,7 @@ pub type DenseMatViewMut<'a> = ndarray::ArrayViewMut2<'a, f32>;
 /// A weight matrix, can be stored in either dense or sparse format.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum WeightMat {
-    Sparse(SparseMat),
+    Sparse(LilMat),
     Dense(DenseMat),
 }
 
@@ -28,7 +28,7 @@ impl WeightMat {
     pub fn dot_vec(&self, vec: SparseVecView) -> DenseVec {
         match self {
             Self::Dense(mat) => mat.outer_iter().map(|w| vec.dot_dense(w)).collect(),
-            Self::Sparse(mat) => sprs::prod::csr_mul_csvec(mat.view(), vec.view()).to_dense(),
+            Self::Sparse(mat) => mat.dot_csvec(vec),
         }
     }
 

--- a/src/model/liblinear.rs
+++ b/src/model/liblinear.rs
@@ -125,13 +125,7 @@ impl HyperParam {
             })
             .collect::<Vec<_>>();
 
-        let mut weights = WeightMat::Sparse(LilMat::from_rows(&weights));
-
-        if weights.density() > 0.5 {
-            weights.densify();
-        }
-
-        weights
+        WeightMat::from_rows(&weights)
     }
 }
 

--- a/src/model/liblinear.rs
+++ b/src/model/liblinear.rs
@@ -125,12 +125,7 @@ impl HyperParam {
             })
             .collect::<Vec<_>>();
 
-        let mut weights = {
-            let rows = weights.iter().map(|v| v.row_view::<usize>()).collect_vec();
-            let row_views = rows.iter().map(|r| r.view()).collect_vec();
-            let mat = sprs::vstack(&row_views);
-            WeightMat::Sparse(mat)
-        };
+        let mut weights = WeightMat::Sparse(LilMat::from_rows(&weights));
 
         if weights.density() > 0.5 {
             weights.densify();

--- a/src/model/liblinear.rs
+++ b/src/model/liblinear.rs
@@ -134,7 +134,7 @@ pub(crate) fn predict(
     loss_type: LossType,
     feature_vec: &SparseVec,
 ) -> DenseVec {
-    let scores = weights.dot_vec(feature_vec.view());
+    let scores = weights.t_dot_vec(feature_vec.view());
     match loss_type {
         LossType::Log => scores.mapv(|score| -(-score).exp().ln_1p()),
         LossType::Hinge => scores.mapv(|score| -(1. - score).max(0.).powi(2)),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -236,37 +236,29 @@ impl Model {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 enum TreeNode {
     Branch {
-        weights: Vec<Option<Vector>>,
+        weights: WeightMat,
         children: Vec<TreeNode>,
     },
     Leaf {
-        weights: Vec<Option<Vector>>,
+        weights: WeightMat,
         labels: Vec<Index>,
     },
 }
 
 impl TreeNode {
     fn is_valid(&self, settings: Settings) -> bool {
-        let is_weight_vec_valid = |w: &Option<Vector>| {
-            if let Some(ref v) = w {
-                v.dim() == settings.n_features + 1 // +1 because it includes bias
-            } else {
-                true
-            }
-        };
         match self {
             TreeNode::Branch {
                 ref weights,
                 ref children,
             } => {
-                weights.len() == children.len()
-                    && weights.iter().all(is_weight_vec_valid)
+                weights.shape() == (children.len(), settings.n_features + 1)
                     && children.iter().all(|c| c.is_valid(settings))
             }
             TreeNode::Leaf {
                 ref weights,
                 ref labels,
-            } => weights.len() == labels.len() && weights.iter().all(is_weight_vec_valid),
+            } => weights.shape() == (labels.len(), settings.n_features + 1),
         }
     }
 
@@ -275,11 +267,9 @@ impl TreeNode {
     }
 
     fn densify_weights(&mut self, max_sparse_density: f32) {
-        fn densify(weights: &mut [Option<Vector>], max_sparse_density: f32) {
-            for w in weights.iter_mut().flatten() {
-                if !w.is_dense() && w.density() > max_sparse_density {
-                    w.densify();
-                }
+        fn densify(weights: &mut WeightMat, max_sparse_density: f32) {
+            if !weights.is_dense() && weights.density() > max_sparse_density {
+                weights.densify();
             }
         }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -252,13 +252,13 @@ impl TreeNode {
                 ref weights,
                 ref children,
             } => {
-                weights.shape() == (children.len(), settings.n_features + 1)
+                weights.shape() == (settings.n_features + 1, children.len())
                     && children.iter().all(|c| c.is_valid(settings))
             }
             TreeNode::Leaf {
                 ref weights,
                 ref labels,
-            } => weights.shape() == (labels.len(), settings.n_features + 1),
+            } => weights.shape() == (settings.n_features + 1, labels.len()),
         }
     }
 

--- a/src/model/train.rs
+++ b/src/model/train.rs
@@ -298,7 +298,7 @@ impl TreeTrainer {
             )))
         };
 
-        assert_eq!(weights.shape().0, label_to_example_indices.len());
+        assert_eq!(weights.shape().1, label_to_example_indices.len());
         self.progress_bar
             .lock()
             .expect("Failed to lock progress bar")

--- a/src/model/train.rs
+++ b/src/model/train.rs
@@ -292,7 +292,7 @@ impl TreeTrainer {
             self.classifier_hyper_param(examples.len())
                 .train(&examples.feature_matrix.view(), label_to_example_indices)
         } else {
-            WeightMat::Sparse(SparseMat::zero((
+            WeightMat::Sparse(LilMat::new((
                 label_to_example_indices.len(),
                 examples.feature_matrix.cols(),
             )))

--- a/src/model/train.rs
+++ b/src/model/train.rs
@@ -287,21 +287,24 @@ impl TreeTrainer {
         &self,
         examples: Arc<TrainingExamples>,
         label_to_example_indices: &[Vec<usize>],
-    ) -> Vec<Option<Vector>> {
-        let classifier_weights = if !self.hyper_param.tree_structure_only {
+    ) -> WeightMat {
+        let weights = if !self.hyper_param.tree_structure_only {
             self.classifier_hyper_param(examples.len())
                 .train(&examples.feature_matrix.view(), label_to_example_indices)
         } else {
-            vec![None; label_to_example_indices.len()]
+            WeightMat::Sparse(SparseMat::zero((
+                label_to_example_indices.len(),
+                examples.feature_matrix.cols(),
+            )))
         };
 
-        assert_eq!(classifier_weights.len(), label_to_example_indices.len());
+        assert_eq!(weights.shape().0, label_to_example_indices.len());
         self.progress_bar
             .lock()
             .expect("Failed to lock progress bar")
             .add(label_to_example_indices.len() as u64);
 
-        classifier_weights
+        weights
     }
 }
 


### PR DESCRIPTION
# Background

During prediction, one major bottleneck is the computation of sparse-sparse dot product between the input feature vector and each branch/label weight vector on each node. For example, if the two vectors have M and N non-zero elements, respectively, a simple "marching pointers" implementation would have O(M + N) time complexity. Note that even though both are *sparse* vectors, N could still be enormous given the possible high feature dimension--e.g., 10% of 10 million is still 1 million.

In the current implementation, we support reducing the time complexity to O(M) at the cost of using more memory by storing some of the "*relatively* dense" sparse weight vectors in dense format, determined by the `--max_sparse_density` option. Observe that, on the one hand, weight vectors generally get denser the closer they are to the root (since they represent a wider variety of labels). On the other hand, the number of nodes shrinks exponentially the smaller the depth is (for a balanced tree at least). Therefore appropriately setting `--max_sparse_density` could achieve a very noticeable speed-up without the model taking up too much memory.

Alternatively, we could also compute the sparse-sparse vector products using binary search. This was introduced in 604970116c69900c12ce12161ea9b3d827961684 which did speed up sparse-sparse vector product in general, but was later removed in cdc71adfb2d707996d5d2b71031c617d188c5f4a because it might slightly slow down the overall prediction when `--max_sparse_density` is small enough. One possible reason could be that when both vectors are sufficiently sparse, the cost of cache misses caused by binary searches overshadows the improvement in asymptotic time complexity.

# About this change

This pull request implements a technique very similar to what's described by Etter et al. (2021) to replace the naive "marching pointers" implementation for calculating sparse-sparse products.

The basic idea is similar to how we efficiently rank relevant documents in information retrieval. We can see the input feature vector as the query and weight vectors of all branches/labels as documents. We want to calculate the similarity between the query and each document measured by the dot product between their vectors.

Both query and document vectors are high-dimensional, but the number of non-zero elements in a query vector is typically drastically smaller. Therefore, we can build an inverted index for the documents in which non-zero values from all documents on the same dimension are stored and quickly retrieved together. Using this index, for each non-zero query dimension, we can efficiently compute how much this dimension contributes to the dot product with each document, and adding them up for each document gives us the final result.

In this implementation, the "inverted index" is just a list-of-lists sparse matrix that stores feature indices in sorted order, so that we can locate any given feature index by binary search. Therefore, to compute the query-document dot products for all documents, we only need to do a "combined" binary search once for all documents simultaneously, as opposed to doing the expensive and cache-unfriendly binary search multiple times, once for every document. Also, we expect the number of "combined" non-zero feature indices not to be too much greater than individual documents: since the "documents" on each node are labels from the same cluster, their weight vectors tend to share the same non-zero dimensions.

**Note: since this changes how weights are stored, it also breaks the compatibility of saved model files.**

# Benchmarks

We tested the prediction speed of the new implementation (labeled "new") on the Amazon-670K dataset, which contains 670,091 labels and 153,025 test examples of dimension 135,909. For comparison, we also run the same test on the implementation from the current master branch (labeled "current"), as well as a slightly changed version that uses binary search to compute sparse-sparse vector dot products (labeled "current-bsearch").

We varied `--max_sparse_density` between 0.01 and 0.5 to get different tradeoffs between space and time. We only use a single thread to reduce noise (`--n_threads 1`).

For the Parabel model (i.e., deep trees built with balanced 2-means clustering), we plot throughput (number of predictions per second) against estimated memory usage:

![image](https://user-images.githubusercontent.com/513210/144698817-af8fe9bf-7cb7-437d-a492-0fcb0396f591.png)

The graph shows that the new implementation can easily be several times faster for the same memory usage. In other words, the new implementation can achieve the same throughput/latency using only a fraction of the memory as before.

The general results also hold for the Bonsai model (i.e., shallow trees built with regular k-means clustering), except that the advantage of the new implementation is even more pronounced:

![image](https://user-images.githubusercontent.com/513210/144699068-9486b3ff-db0a-492b-8c8f-9f8c729b2fe1.png)

# Future work

In the future, we will explore indexing the features in weight matrices using hash maps. Compared to storing the whole matrix in dense format, it might achieve comparable speed-up while using much less extra memory.

# Reference

- Etter, P. A., Zhong, K., Yu, H.-F., Ying, L., & Dhillon, I. (2021). Accelerating Inference for Sparse Extreme Multi-Label Ranking Trees. Retrieved from http://arxiv.org/abs/2106.02697