### PR TITLE
Limit number of label candidates per leaf for prediction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ dependencies = [
  "order-stat",
  "ordered-float",
  "pbr",
+ "pdqselect",
  "rand",
  "rayon",
  "serde",
@@ -366,6 +367,12 @@ dependencies = [
  "time 0.1.43",
  "winapi",
 ]
+
+[[package]]
+name = "pdqselect"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7778906d9321dd56cde1d1ffa69a73e59dcf5fda6d366f62727adf2bd4193aee"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_cbor = "0.11.*"
 serde_json = "1.0.*"
 simple_logger = { version = "1.15.*", features = ["stderr"], optional = true }
 sprs = { version = "0.9.*", features = ["serde"] }
+pdqselect = "0.1.*"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.*"

--- a/c-api/Cargo.lock
+++ b/c-api/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "order-stat",
  "ordered-float",
  "pbr",
+ "pdqselect",
  "rand",
  "rayon",
  "serde",
@@ -406,6 +407,12 @@ dependencies = [
  "time 0.1.43",
  "winapi",
 ]
+
+[[package]]
+name = "pdqselect"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7778906d9321dd56cde1d1ffa69a73e59dcf5fda6d366f62727adf2bd4193aee"
 
 [[package]]
 name = "ppv-lite86"


### PR DESCRIPTION
Before this change, when beam search reaches leaves, we return all labels on all these leaves as candidates. It turns out that for wide & shallow trees (e.g., "bonsai"), the labels on each leaf can be quite large. As a result, we end up wasting a significant portion of prediction time to rank all these labels, despite the vast majority of them not being relevant at all.

We tested the change on a "bonsai" model (unbalanced k-means clustering where k=100, max depth 3) trained on the Amazon-670K dataset (670,091 labels, 153,025 test examples of dimension 135,909).  During prediction, the default arguments are used, except that we only use a single thread to reduce noise (`--n_threads 1`). This change reduces the average prediction time per example by ~36%, from 2.5ms to 1.6ms.