### PR TITLE
Update simple_logger to avoid throwing local-time-related error during logger initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "1.9.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "simple_logger"
-version = "1.15.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205596cf77a15774e5601c5ef759f4211ac381c0855a1f1d5e24a46f60f93e9a"
+checksum = "c75a9723083573ace81ad0cdfc50b858aa3c366c48636edb4109d73122a0c0ea"
 dependencies = [
  "atty",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rayon = "1.5.*"
 serde = { version = '1.0.*', features = ['derive'] }
 serde_cbor = "0.11.*"
 serde_json = "1.0.*"
-simple_logger = { version = "1.15.*", features = ["stderr"], optional = true }
+simple_logger = { version = "2.1.*", features = ["stderr"], optional = true }
 sprs = { version = "0.9.*", features = ["serde"] }
 pdqselect = "0.1.*"
 

--- a/c-api/Cargo.lock
+++ b/c-api/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "1.9.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "simple_logger"
-version = "1.15.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205596cf77a15774e5601c5ef759f4211ac381c0855a1f1d5e24a46f60f93e9a"
+checksum = "c75a9723083573ace81ad0cdfc50b858aa3c366c48636edb4109d73122a0c0ea"
 dependencies = [
  "atty",
  "colored",

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["staticlib", "cdylib"]
 itertools = "0.10.*"
 libc = "0.2.*"
 omikuji = { path = ".." }
-simple_logger = "1.15.*"
+simple_logger = "2.1.*"
 
 [build-dependencies]
 cbindgen = "0.20.*"


### PR DESCRIPTION
According to borntyping/rust-simple_logger#52, this should fix #37