### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -51,8 +51,6 @@ stages:
         container: 'quay.io/pypa/manylinux2010_x86_64:latest'
         strategy:
           matrix:
-            Python3.6:
-              python.version: 3.6
             Python3.7:
               python.version: 3.7
             Python3.8:
@@ -69,8 +67,6 @@ stages:
           vmImage: 'windows-2019'
         strategy:
           matrix:
-            Python3.6:
-              python.version: 3.6
             Python3.7:
               python.version: 3.7
             Python3.8:
@@ -85,8 +81,6 @@ stages:
           vmImage: 'macOS-1015'
         strategy:
           matrix:
-            Python3.6:
-              python.version: 3.6
             Python3.7:
               python.version: 3.7
             Python3.8:

--- a/.ci/azure-python-build.yml
+++ b/.ci/azure-python-build.yml
@@ -24,9 +24,6 @@ steps:
       set -e
 
       case $(python.version) in
-      3.6)
-        LANG_ABI_VER="cp36-cp36m"
-        ;;
       3.7)
         LANG_ABI_VER="cp37-cp37m"
         ;;
@@ -46,9 +43,6 @@ steps:
       set -e
 
       case $(python.version) in
-      3.6)
-        FULL_VERSION=3.6.8
-        ;;
       3.7)
         FULL_VERSION=3.7.9
         ;;

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     ),
     long_description=load_readme(),
     long_description_content_type="text/markdown",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     url="https://github.com/tomtung/omikuji",
     license="MIT",
     packages=["omikuji"],
@@ -50,8 +50,6 @@ setup(
     milksnake_universal=False,
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Python 3.6 has reached its end-of-life date, and no longer supported by the latest version of pip, which is breaking our CI scripts.