### PR TITLE
Trainining Omikuji from scipy.sparse.csr_matrix

### DIFF
--- a/python-wrapper/omikuji/__init__.py
+++ b/python-wrapper/omikuji/__init__.py
@@ -218,7 +218,7 @@ class Model:
 
         # Creates and map the rust feature vectors from the numpy arrays
         feature_indices = ffi.new("uint32_t[]", num_nnz_features)
-        feature_indptr = ffi.new("uint32_t[]", num_feature_rows+1)
+        feature_indptr = ffi.new("uint32_t[]", num_feature_rows + 1)
         feature_data = ffi.new("float[]", num_nnz_features)
         feature_indices = ffi.from_buffer("uint32_t[]", features.indices)
         feature_indptr = ffi.from_buffer("uint32_t[]", features.indptr)
@@ -226,7 +226,7 @@ class Model:
 
         # Creates and map the rust label vectors from the numpy arrays
         label_indices = ffi.new("uint32_t[]", num_nnz_labels)
-        label_indptr = ffi.new("uint32_t[]", num_labels_rows+1)
+        label_indptr = ffi.new("uint32_t[]", num_labels_rows + 1)
         label_data = ffi.new("uint32_t[]", num_nnz_labels)
         label_indices = ffi.from_buffer("uint32_t[]", labels.indices)
         label_indptr = ffi.from_buffer("uint32_t[]", labels.indptr)

--- a/src/data.rs
+++ b/src/data.rs
@@ -125,6 +125,7 @@ impl DataSet {
             .skip(1)
             .map(|line| Self::parse_xc_repo_data_line(line, n_features))
             .collect::<Result<_>>()?;
+
         let (feature_lists, label_sets): (Vec<_>, Vec<_>) = lines.into_iter().unzip();
 
         if n_examples != feature_lists.len() {
@@ -143,6 +144,19 @@ impl DataSet {
             n_examples,
             start_t.elapsed().as_secs_f32()
         );
+        Ok(Self {
+            n_features,
+            n_labels,
+            feature_lists,
+            label_sets,
+        })
+    }
+//feature_lists: Vec<IndexValueVec>
+    pub fn from_x_y(n_features: usize, n_labels: usize, feature_lists: Vec<IndexValueVec>, label_sets: Vec<IndexSet>) -> Result<Self> 
+    {
+        info!("Total number of features {}", n_features);
+        info!("Total number of labels {}", n_labels);
+        info!("Num rows {}", feature_lists.len());
         Ok(Self {
             n_features,
             n_labels,


### PR DESCRIPTION
I've adapted an alternative method to train the omikuji model by bypassing disk write for the Python wrapper.

The main work is based on the creation of a new methods in the `lib.rs` file called `load_omikuji_data_set_from_features_labels`.

It is designed to take in the three main numpy arrays defining the underlying structure of the `scipy.sparse.csr_matrix`.
In other words I map the `scipy.sparse.csr_matrix.{indices, indptr, data}` arrays into Rust vectors, and then I recreate a features matrix together with the labels set, in a way similar to the `train_on_data` method.